### PR TITLE
test: init tests in internal/admin

### DIFF
--- a/internal/admin/admin_client.go
+++ b/internal/admin/admin_client.go
@@ -32,10 +32,12 @@ func (rs *HMetaStatus) IsAllReady() bool {
 	if len(rs.Nodes) == 0 {
 		return false
 	}
+
 	for _, node := range rs.Nodes {
 		if !node.Reachable {
 			return false
 		}
 	}
+
 	return true
 }

--- a/internal/admin/admin_suite_test.go
+++ b/internal/admin/admin_suite_test.go
@@ -1,0 +1,13 @@
+package admin_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAdmin(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admin Suite")
+}

--- a/internal/admin/client.go
+++ b/internal/admin/client.go
@@ -35,14 +35,14 @@ func (p *realAdminClientProvider) GetAdminClient(hdb *hapi.HStreamDB) AdminClien
 // NewAdminClientProvider generates a client provider for talking to real hStream.
 func NewAdminClientProvider(restConfig *rest.Config, log logr.Logger) AdminClientProvider {
 	return &realAdminClientProvider{
-		log:        log.WithName("adminClient"),
+		log:        log.WithName("Admin Client"),
 		restConfig: restConfig,
 	}
 }
 
 type adminClient struct {
 	hdb        *hapi.HStreamDB
-	remoteExec *Executor
+	remoteExec FactoryExecutor
 	log        logr.Logger
 }
 
@@ -54,12 +54,6 @@ func NewAdminClient(hdb *hapi.HStreamDB, restConfig *rest.Config, log logr.Logge
 		log: log.WithValues("namespace", hdb.Namespace).
 			WithValues("instance", hdb.Name),
 	}
-}
-
-type cmdOrder struct {
-	args        []string
-	resultCheck func(output string) (skipSubCmd bool, err error)
-	subCmd      *cmdOrder
 }
 
 // BootstrapHStore init hStore cluster
@@ -140,7 +134,7 @@ func (ac *adminClient) GetHMetaStatus() (status HMetaStatus, err error) {
 
 	err = json.Unmarshal(resp, &status.Nodes)
 	if err != nil {
-		err = fmt.Errorf("unmarshal HMeta staus failed. %w", err)
+		err = fmt.Errorf("unmarshal HMeta status failed: %w", err)
 		return
 	}
 	return

--- a/internal/admin/client_test.go
+++ b/internal/admin/client_test.go
@@ -1,0 +1,45 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/hstreamdb/hstream-operator/mock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Client", func() {
+	var ac *adminClient
+
+	BeforeEach(func() {
+		ac = &adminClient{
+			remoteExec: &mockExecutor{},
+			hdb:        mock.CreateDefaultCR(),
+		}
+	})
+
+	Context("GetHMetaStatus", func() {
+		It("should return expected status", func() {
+			ac.remoteExec.(*mockExecutor).getAPIByService = func(namespace, serviceName, path string) ([]byte, int, error) {
+				nodes := map[string]HMetaNode{
+					"node1": {
+						Reachable: true,
+					},
+					"node2": {
+						Reachable: true,
+					},
+				}
+				resp, _ := json.Marshal(nodes)
+
+				return resp, http.StatusOK, nil
+			}
+
+			status, err := ac.GetHMetaStatus()
+
+			Expect(err).NotTo(HaveOccurred())
+			for _, node := range status.Nodes {
+				Expect(node.Reachable).To(Equal(true))
+			}
+		})
+	})
+})

--- a/internal/admin/remote_cmd.go
+++ b/internal/admin/remote_cmd.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
+	"time"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -13,9 +16,13 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
-	"net/http"
-	"time"
 )
+
+type FactoryExecutor interface {
+	getPodNameByLabel(namespace string, label map[string]string) (name string, err error)
+	ExecToPodByLabel(namespace string, label map[string]string, containerName, command string, timeout time.Duration) (output string, err error)
+	GetAPIByService(namespace, serviceName, path string) (output []byte, statusCode int, err error)
+}
 
 type Executor struct {
 	clientSet  *kubernetes.Clientset

--- a/internal/admin/remote_cmd_mock.go
+++ b/internal/admin/remote_cmd_mock.go
@@ -1,0 +1,21 @@
+package admin
+
+import (
+	"time"
+)
+
+type mockExecutor struct {
+	getAPIByService func(namespace, serviceName, path string) (output []byte, statusCode int, err error)
+}
+
+func (e *mockExecutor) getPodNameByLabel(namespace string, label map[string]string) (name string, err error) {
+	panic("implement me")
+}
+
+func (e *mockExecutor) ExecToPodByLabel(namespace string, label map[string]string, containerName, command string, timeout time.Duration) (output string, err error) {
+	panic("implement me")
+}
+
+func (e *mockExecutor) GetAPIByService(namespace, serviceName, path string) ([]byte, int, error) {
+	return e.getAPIByService(namespace, serviceName, path)
+}


### PR DESCRIPTION
Starting to supplement tests in the `internal/admin` package. Still in progress.