### PR TITLE
fix: gateway port can be omitted

### DIFF
--- a/api/v1alpha2/gateway.go
+++ b/api/v1alpha2/gateway.go
@@ -7,7 +7,7 @@ type Gateway struct {
 	//+kubebuilder:validation:Required
 	Endpoint string `json:"endpoint"`
 	//+kubebuilder:default:=14789
-	Port int32 `json:"port"`
+	Port int32 `json:"port,omitempty"`
 	// Must 'kubernetes.io/tls' secret, and the tls.key must the PKCS8 format
 	SecretRef *corev1.LocalObjectReference `json:"secretRef,omitempty"`
 }

--- a/config/crd/bases/apps.hstream.io_hstreamdbs.yaml
+++ b/config/crd/bases/apps.hstream.io_hstreamdbs.yaml
@@ -9264,7 +9264,6 @@ spec:
                 - container
                 - endpoint
                 - image
-                - port
                 - replicas
                 type: object
               hmeta:

--- a/deploy/charts/hstream-operator/crds/apps.hstream.io_hstreamdbs.yaml
+++ b/deploy/charts/hstream-operator/crds/apps.hstream.io_hstreamdbs.yaml
@@ -9264,7 +9264,6 @@ spec:
                 - container
                 - endpoint
                 - image
-                - port
                 - replicas
                 type: object
               hmeta:


### PR DESCRIPTION
Since the `port` has a default value, it is unnecessary to include it in the spec.