### PR TITLE
chore: move hserver constants into pkg

### DIFF
--- a/internal/admin/client.go
+++ b/internal/admin/client.go
@@ -126,7 +126,7 @@ func (ac *adminClient) GetHMetaStatus() (status HMetaStatus, err error) {
 	} else {
 		namespace = ac.hdb.Namespace
 		svc := internal.GetHeadlessService(ac.hdb, hapi.ComponentTypeHMeta)
-		hmetaAddr = fmt.Sprintf("%s:%d", svc.Name, constants.HMetaDefaultPort.ContainerPort)
+		hmetaAddr = fmt.Sprintf("%s:%d", svc.Name, constants.DefaultHMetaPort.ContainerPort)
 	}
 
 	resp, statusCode, err := ac.remoteExec.GetAPIByService(namespace, hmetaAddr, "nodes")

--- a/internal/controller/add_console.go
+++ b/internal/controller/add_console.go
@@ -8,6 +8,7 @@ import (
 
 	hapi "github.com/hstreamdb/hstream-operator/api/v1alpha2"
 	"github.com/hstreamdb/hstream-operator/internal"
+	"github.com/hstreamdb/hstream-operator/pkg/constants"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -162,7 +163,7 @@ func (a addConsole) getContainer(hdb *hapi.HStreamDB) ([]corev1.Container, error
 
 	if _, ok := args["-Dplain.hstream.privateAddress"]; !ok {
 		hServerContainer := &hdb.Spec.HServer.Container
-		ports := coverPortsFromArgs(hServerContainer.Args, extendPorts(hServerContainer.Ports, hServerPort))
+		ports := coverPortsFromArgs(hServerContainer.Args, extendPorts(hServerContainer.Ports, constants.DefaultHServerPort))
 		port := int32(0)
 		for i := range ports {
 			if ports[i].Name == "port" {

--- a/internal/controller/add_console_test.go
+++ b/internal/controller/add_console_test.go
@@ -7,6 +7,7 @@ import (
 	hapi "github.com/hstreamdb/hstream-operator/api/v1alpha2"
 	"github.com/hstreamdb/hstream-operator/internal"
 	"github.com/hstreamdb/hstream-operator/mock"
+	"github.com/hstreamdb/hstream-operator/pkg/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -72,7 +73,7 @@ var _ = Describe("AddConsole", func() {
 			Context("should contain default config", func() {
 				It("should get default env", func() {
 					hServerContainer := &hdb.Spec.HServer.Container
-					ports := coverPortsFromArgs(hServerContainer.Args, extendPorts(hServerContainer.Ports, hServerPort))
+					ports := coverPortsFromArgs(hServerContainer.Args, extendPorts(hServerContainer.Ports, constants.DefaultHServerPort))
 					port := int32(0)
 					for i := range ports {
 						if ports[i].Name == "port" {

--- a/internal/controller/add_geteway.go
+++ b/internal/controller/add_geteway.go
@@ -7,6 +7,7 @@ import (
 
 	hapi "github.com/hstreamdb/hstream-operator/api/v1alpha2"
 	"github.com/hstreamdb/hstream-operator/internal"
+	"github.com/hstreamdb/hstream-operator/pkg/constants"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -163,5 +164,5 @@ func findHServerPort(ctx context.Context, r *HStreamDBReconciler, hdb *hapi.HStr
 			}
 		}
 	}
-	return hServerPort.ContainerPort
+	return constants.DefaultHServerPort.ContainerPort
 }

--- a/internal/controller/add_hmeta.go
+++ b/internal/controller/add_hmeta.go
@@ -109,7 +109,7 @@ func (a addHMeta) getContainer(hdb *hapi.HStreamDB) []corev1.Container {
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path:   "/readyz",
-					Port:   intstr.FromInt(int(constants.HMetaDefaultPort.ContainerPort)),
+					Port:   intstr.FromInt(int(constants.DefaultHMetaPort.ContainerPort)),
 					Scheme: "HTTP",
 				},
 			},
@@ -121,7 +121,7 @@ func (a addHMeta) getContainer(hdb *hapi.HStreamDB) []corev1.Container {
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path:   "/readyz?noleader",
-					Port:   intstr.FromInt(int(constants.HMetaDefaultPort.ContainerPort)),
+					Port:   intstr.FromInt(int(constants.DefaultHMetaPort.ContainerPort)),
 					Scheme: "HTTP",
 				},
 			},

--- a/internal/controller/add_services.go
+++ b/internal/controller/add_services.go
@@ -6,6 +6,7 @@ import (
 
 	hapi "github.com/hstreamdb/hstream-operator/api/v1alpha2"
 	"github.com/hstreamdb/hstream-operator/internal"
+	"github.com/hstreamdb/hstream-operator/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,7 +34,7 @@ func (a addServices) reconcile(ctx context.Context, r *HStreamDBReconciler, hdb 
 
 func (a addServices) addHServerService(ctx context.Context, r *HStreamDBReconciler, hdb *hapi.HStreamDB) (err error) {
 	hserver := &hdb.Spec.HServer
-	ports, err := getPorts(&hserver.Container, hServerPort, hServerInternalPort)
+	ports, err := getPorts(&hserver.Container, constants.DefaultHServerPort, constants.DefaultHServerInternalPort)
 	if err != nil {
 		return fmt.Errorf("parse hServer args failed. %w", err)
 	}

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -134,7 +134,7 @@ func extendPorts(ports []corev1.ContainerPort, externalPorts ...corev1.Container
 	return ports
 }
 
-// coverPorts use the port in user-defined args to cover the default port
+// coverPortsFromArgs use the port in user-defined args to cover the default port
 func coverPortsFromArgs(args []string, ports []corev1.ContainerPort) []corev1.ContainerPort {
 	newPorts := make([]corev1.ContainerPort, len(ports))
 	copy(newPorts, ports)
@@ -144,11 +144,13 @@ func coverPortsFromArgs(args []string, ports []corev1.ContainerPort) []corev1.Co
 	parsedArgs := flags.Flags()
 
 	for i := range ports {
-		name := (&ports[i]).Name
+		name := ports[i].Name
+
 		if port, ok := parsedArgs["--"+name]; ok {
 			newPorts[i].ContainerPort = intstr.Parse(port).IntVal
 		}
 	}
+
 	return newPorts
 }
 
@@ -197,7 +199,7 @@ func getHMetaAddr(hdb *hapi.HStreamDB) (string, error) {
 func parseHMetaPort(args []string) (corev1.ContainerPort, error) {
 	flags := internal.FlagSet{}
 	if err := flags.Parse(args); err != nil {
-		return constants.HMetaDefaultPort, err
+		return constants.DefaultHMetaPort, err
 	}
 	if addr, ok := flags.Flags()["--http-addr"]; ok {
 		if slice := strings.Split(addr, ":"); len(slice) == 2 {
@@ -209,5 +211,5 @@ func parseHMetaPort(args []string) (corev1.ContainerPort, error) {
 		}
 	}
 
-	return constants.HMetaDefaultPort, nil
+	return constants.DefaultHMetaPort, nil
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -4,7 +4,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var HMetaDefaultPort = corev1.ContainerPort{
+var DefaultHServerPort = corev1.ContainerPort{
+	Name:          "port",
+	ContainerPort: 6570,
+	Protocol:      corev1.ProtocolTCP,
+}
+
+var DefaultHServerInternalPort = corev1.ContainerPort{
+	Name:          "internal-port",
+	ContainerPort: 6571,
+	Protocol:      corev1.ProtocolTCP,
+}
+
+var DefaultHMetaPort = corev1.ContainerPort{
 	Name:          "rqlite",
 	ContainerPort: 4001,
 	Protocol:      corev1.ProtocolTCP,


### PR DESCRIPTION
Move default HServer ports into `pkg/constants` for better management.