### PR TITLE
chore: preparing for 0.0.9

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           prerelease: ${{ steps.prerelease.outputs.prerelease }}
           token: ${{ github.token }}
-          name: HStream Operator ${{ github.ref_name }} Released
+          name: HStream Operator ${{ github.ref_name }}
           body_path: RELEASE.md
           generate_release_notes: true
           files: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.9] - 2023-11-22
+
+### Added
+
+- Now you can specify image registry in `Connector` CRD with `spec.imageRegistry` field.
+- Now you can customize container spec in `Connector` CRD with `spec.container` field.
+
+[unreleased]: https://github.com/hstreamdb/hstream-operator/compare/0.0.9...HEAD
+[0.0.9]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/0.0.9

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,25 +1,3 @@
-## Release Note 🍻
+HStream Operator 0.0.9 has been released.
 
-HStream Operator 0.0.8 has been released.
-
-### Supported version
-
-- `apps.hstream.io/v1alpha2`
-
-  - `HStreamDB` with [rqlite](https://hub.docker.com/layers/hstreamdb/hstream/rqlite_v0.17.3/images/sha256-a7d489f2b33959f6a4326850f143ccbca914240092d0f2f706c23679e369a9b5?context=explore)
-
-### Enhancements 🚀
-
-- `apps.hstream.io/v1alpha2`
-
-  - Moderate readiness probes in hserver and hmeta.
-
-- `apps.hstream.io/v1beta1`
-
-  Support new kinds: `ConnectorTemplate` and `Connector`, which can be used to create and manage HStream IO Connectors. Currently supported connectors are:
-
-  - `sink-elasticsearch`: Sink data to ElasticSearch.
-
-### Warning 🚨
-
-The API version `v1alpha2` isn't compatible with v1alpha1.
+See [CHANGELOG](https://github.com/hstreamdb/hstream-operator/blob/main/CHANGELOG.md) for more details.


### PR DESCRIPTION
This PR also keeps all significant changes in `CHANGELOG.md` to let us not need to modify `RELEASE.md` completely every time.